### PR TITLE
fix: validate window references before operations

### DIFF
--- a/lua/showkeys/init.lua
+++ b/lua/showkeys/init.lua
@@ -18,7 +18,13 @@ M.open = function()
 
   state.timer = vim.loop.new_timer()
   state.on_key = vim.on_key(function(_, char)
-    if not state.win then
+    -- Added check: Verify window exists and is valid
+    if not state.win or not api.nvim_win_is_valid(state.win) then
+      -- Cleanup invalid window reference
+      if state.win then
+        pcall(api.nvim_win_close, state.win, true) 
+      end
+      -- Recreate window if missing/invalid
       state.win = api.nvim_open_win(state.buf, false, state.config.winopts)
       api.nvim_set_option_value("winhl", state.config.winhl, { win = state.win })
     end

--- a/lua/showkeys/ui.lua
+++ b/lua/showkeys/ui.lua
@@ -1,6 +1,18 @@
+-- Added API reference for validity checks
+local api = vim.api  
 local state = require "showkeys.state"
 
 return function()
+  -- Early return if window is invalid
+  if not state.win or not api.nvim_win_is_valid(state.win) then
+    return {}
+  end
+
+  -- Early return if buffer is invalid
+  if not state.buf or not api.nvim_buf_is_valid(state.buf) then
+    return {}
+  end
+
   local list = state.keys
   local list_len = #list
   local virt_txts = {}

--- a/lua/showkeys/utils.lua
+++ b/lua/showkeys/utils.lua
@@ -47,6 +47,16 @@ M.gen_winconfig = function()
 end
 
 local update_win_w = function()
+  -- Check and reset invalid window references
+  if state.win and not api.nvim_win_is_valid(state.win) then
+    state.win = nil
+  end
+
+  -- Early return if window becomes invalid
+  if not state.win then
+    return
+  end
+
   local keyslen = #state.keys
   state.w = keyslen + 1 + (2 * keyslen) -- 2 spaces around each key
 
@@ -55,7 +65,8 @@ local update_win_w = function()
   end
 
   M.gen_winconfig()
-  api.nvim_win_set_config(state.win, state.config.winopts)
+  -- Wrap in pcall to prevent errors from invalid windows
+  pcall(api.nvim_win_set_config, state.win, state.config.winopts)
 end
 
 M.draw = function()
@@ -83,7 +94,10 @@ M.clear_and_close = function()
   M.redraw()
   local tmp = state.win
   state.win = nil
-  api.nvim_win_close(tmp, true)
+  -- PR1: Add window validity check before closing
+  if tmp and api.nvim_win_is_valid(tmp) then
+    api.nvim_win_close(tmp, true)
+  end
 end
 
 M.parse_key = function(char)


### PR DESCRIPTION
## Description

Fixes error: `Invalid 'window': Expected Lua number` by:
- Adding window validity checks before API operations
- Safely resetting invalid window references
- Gracefully handling window recreation

## Changes

- Added `nvim_win_is_valid` checks in critical paths
- Implemented safe window recreation logic
- Added buffer validity checks in UI rendering
- Used `pcall` for protected Neovim API calls