### PR TITLE
fix(buffer): Prevent error when deleting an invalid buffer in WinClosed

### DIFF
--- a/lua/showkeys/init.lua
+++ b/lua/showkeys/init.lua
@@ -75,7 +75,20 @@ M.close = function()
   state.keys = {}
   state.w = 1
   state.extmark_id = nil
-  vim.cmd("bd" .. state.buf)
+  --[[
+    Fix: Check if the buffer is still valid before attempting to delete it.
+    The WinClosed autocommand can be triggered after the buffer has already
+    been deleted, causing an error.
+  ]]
+  if state.buf and api.nvim_buf_is_valid(state.buf) then
+    vim.cmd("bd" .. state.buf)
+  end
+  --[[
+    Fix: Reset the buffer reference to avoid trying to delete it again.
+    This is necessary because the WinClosed autocommand can be triggered
+    multiple times, and we only want to delete the buffer once.
+  ]]
+  state.buf = nil
   vim.on_key(nil, state.on_key)
   state.visible = false
   state.win = nil


### PR DESCRIPTION
The `WinClosed` autocommand was attempting to delete the `showkeys` buffer even after it had been closed, leading to an error. This was happening because the `WinClosed` autocommand was being triggered after the buffer had already been deleted.

This commit addresses the issue by:

-  Adding a check in `M.close` to ensure the buffer is still valid before attempting to delete it using `vim.cmd("bd" .. state.buf)`.
- Reset the buffer reference to avoid trying to delete it again.

