### PR TITLE
refactor(race): Add checks to prevent race conditions in key parsing ……and drawing

### DIFF
--- a/lua/showkeys/utils.lua
+++ b/lua/showkeys/utils.lua
@@ -78,6 +78,15 @@ local update_win_w = function()
 end
 
 M.draw = function()
+  -- Early return if window is invalid
+  if not state.win or not api.nvim_win_is_valid(state.win) then
+    return
+  end
+
+  -- Early return if buffer is invalid
+  if not state.buf or not api.nvim_buf_is_valid(state.buf) then
+    return
+  end
   local virt_txts = require "showkeys.ui"()
 
   if not state.extmark_id then
@@ -109,6 +118,15 @@ M.clear_and_close = function()
 end
 
 M.parse_key = function(char)
+  -- Early return if window is invalid
+  if not state.win or not api.nvim_win_is_valid(state.win) then
+    return
+  end
+
+  -- Early return if buffer is invalid
+  if not state.buf or not api.nvim_buf_is_valid(state.buf) then
+    return
+  end
   local opts = state.config
 
   if vim.tbl_contains(opts.excluded_modes, vim.api.nvim_get_mode().mode) then


### PR DESCRIPTION
This commit adds checks to `M.parse_key` and `M.draw` in `utils.lua` to prevent potential race conditions that could occur when the window or buffer is in an invalid state.

-   **Race Condition Prevention:** Added checks at the beginning of `M.parse_key` to ensure that `state.win` and `state.buf` are valid before proceeding. This prevents errors if a key is pressed while the window is being created or closed.
-   **Race Condition Prevention:** Added checks at the beginning of `M.draw` to ensure that `state.win` and `state.buf` are valid before proceeding. This prevents errors if the window is resized or closed while `M.draw` is being called.

These checks improve the robustness of the plugin by preventing errors that could occur due to timing issues.